### PR TITLE
Use child_process.execFile instead of .exec for more robust parsing.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var globby = require('globby')
 var async = require('async')
-var exec = require('child_process').exec
+var execFile = require('child_process').execFile
 var phpCmd = 'php'
 var os = require('os')
 var crypto = require('crypto')
@@ -11,13 +11,13 @@ var CACHE_DIR = 'php-lint'
 var CACHE_TMP_DIR = os.tmpdir()
 
 function testPhp () {
-  exec(phpCmd + ' -v', function (err, stdout, stderr) {
+  execFile(phpCmd, ['-v'], function (err, stdout, stderr) {
     if (err) throw new Error(err)
   })
 }
 
 function lint (path, callback) {
-  return exec(phpCmd + ' -l ' + path, {
+  return execFile(phpCmd, ['-l', path], {
     cwd: process.cwd(),
     env: process.env
   }, callback)


### PR DESCRIPTION
In particular, I encountered an error when linting PHP scripts whose
names included a space, because the argument passed to the name wasn't
escaped or quoted.  Rather than using a regex or some other "escaping"
invented on the fly, this commit pushes that responsibility back to the
child_process module.