### PR TITLE
Add explicit setting to display errors when calling phplint.

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function testPhp () {
 }
 
 function lint (path, callback) {
-  return execFile(phpCmd, ['-l', path], {
+  return execFile(phpCmd, ['-d', 'display_errors=1', '-l', path], {
     cwd: process.cwd(),
     env: process.env
   }, callback)


### PR DESCRIPTION
this commit fixes #22